### PR TITLE
delete YouTube icon session FAQ

### DIFF
--- a/src/scss/_8-archive.scss
+++ b/src/scss/_8-archive.scss
@@ -149,7 +149,6 @@
 		&.slug-lunch-session-2,
 		&.slug-pm-session-1,
 		&.slug-pm-session-2,
-		&.slug-meeting,
 		&.slug-last-session {
 			.wordcamp-sessions__categories{
 				&::before {


### PR DESCRIPTION
WordPressなんでも質問大会のYouTube配信がなくなったので、アイコンを削除